### PR TITLE
[fix][s] removing broken toc links

### DIFF
--- a/climate-change.md
+++ b/climate-change.md
@@ -9,8 +9,6 @@ image: climate-change.png
 
 What are the most important "general" datasets to have on climate change?
 
-[[toc]]
-
 ## Policy
 
 * Country or sub-region commitments (e.g. emission amounts, cuts, temperature targets)

--- a/demographics.md
+++ b/demographics.md
@@ -11,19 +11,19 @@ image: demographics.png
 
 Data comes originally from World Bank and has been converted into standard CSV:
 
-[core/population](/core/population)
+[core/population](https://datahub.io/core/population)
 
 ## City Population Annual Time Series (UN Statistics Division)
 
 UNSD Demographic Statistics: City population by sex, city and city type:
 
-[core/population-city](/core/population-city)
+[core/population-city](https://datahub.io/core/population-city)
 
 ## Global Historical Population
 
 The population data starts from -1000000 BC to 1990 with the average number of people. There are several population data from the different reports such as Deevey, McEvedy and Jones 1978, Durand Low, Durand High, Clark,Biraben, Blaxter, UN, Kremer:
 
-[core/population-global-historical](/core/population-global-historical)
+[core/population-global-historical](https://datahub.io/core/population-global-historical)
 
 ## Population Growth
 

--- a/economic-data.md
+++ b/economic-data.md
@@ -9,8 +9,6 @@ image: economic-data.png
 
 On this page, we summarize all available economic data (or economic statistics) on DataHub. Users can find various examples of economic indicators or explore data by country. The page is curated and updated on regular basis so don't forget to bookmark it!
 
-[[toc]]
-
 ## Basic economic data
 
 Following datasets can be considered as basic economic indicators:

--- a/economic-data.md
+++ b/economic-data.md
@@ -13,57 +13,57 @@ On this page, we summarize all available economic data (or economic statistics) 
 
 Following datasets can be considered as basic economic indicators:
 
-* [GDP](/core/gdp) - Country, Regional and World GDP (Gross Domestic Product).
-* [CPI](/core/cpi) - Annual Consumer Price Index (CPI) for most countries in the world.
-* [Inflation](/core/inflation) - Annual inflation by GDP deflator and consumer prices.
-* [Population](/core/population) - Population figures for countries, regions (e.g. Asia) and the world.
-* [Cash Surplus Deficit](/core/cash-surplus-deficit) - Cash Surplus/Deficit, in % of GDP, from 1990 to 2013.
+* [GDP](https://datahub.io/core/gdp) - Country, Regional and World GDP (Gross Domestic Product).
+* [CPI](https://datahub.io/core/cpi) - Annual Consumer Price Index (CPI) for most countries in the world.
+* [Inflation](https://datahub.io/core/inflation) - Annual inflation by GDP deflator and consumer prices.
+* [Population](https://datahub.io/core/population) - Population figures for countries, regions (e.g. Asia) and the world.
+* [Cash Surplus Deficit](https://datahub.io/core/cash-surplus-deficit) - Cash Surplus/Deficit, in % of GDP, from 1990 to 2013.
 * [Other Economic Data](#other-economic-data-and-indicators)
 
 ## US economic data
 
 Economic indicators for the United States:
 
-* [GDP](/core/gdp-us) - Gross Domestic Product (GDP) of the United States (US) both nominal and real on an annual and quarterly basis.
-* [Employment](/core/employment-us) - US Employment and Unemployment rates since 1940.
-* [CPI](/core/cpi-us) - US Consumer Price Index and Inflation (CPI).
-* [Bond Yields](/core/bond-yields-us-10y) - 10 year US Government Bond Yields (long-term interest rate).
-* [House Prices](/core/house-prices-us) - US House Price Index (Case-Shiller).
-* [Household Incomes](/core/household-income-us-historical) - Income Limits for Each Fifth and Top 5 Percent of All Households: 1967 to 2016.
-* [Investor Flow of Funds](/core/investor-flow-of-funds-us) - US Investor Flow of Funds into Investment Classes (Bonds, Equities etc).
-* [Education Budget](/core/usa-education-budget-analysis) - US Education Budget Analysis.
+* [GDP](https://datahub.io/core/gdp-us) - Gross Domestic Product (GDP) of the United States (US) both nominal and real on an annual and quarterly basis.
+* [Employment](https://datahub.io/core/employment-us) - US Employment and Unemployment rates since 1940.
+* [CPI](https://datahub.io/core/cpi-us) - US Consumer Price Index and Inflation (CPI).
+* [Bond Yields](https://datahub.io/core/bond-yields-us-10y) - 10 year US Government Bond Yields (long-term interest rate).
+* [House Prices](https://datahub.io/core/house-prices-us) - US House Price Index (Case-Shiller).
+* [Household Incomes](https://datahub.io/core/household-income-us-historical) - Income Limits for Each Fifth and Top 5 Percent of All Households: 1967 to 2016.
+* [Investor Flow of Funds](https://datahub.io/core/investor-flow-of-funds-us) - US Investor Flow of Funds into Investment Classes (Bonds, Equities etc).
+* [Education Budget](https://datahub.io/core/usa-education-budget-analysis) - US Education Budget Analysis.
 
 ## UK economic data
 
 Economic indicators for the United Kingdom:
 
-* [GDP](/core/gdp-uk) - UK Real GDP since 1948 from the Office of National Statistics.
-* [Bond Yields](/core/bond-yields-uk-10y) - 10 year nominal yields on UK government bonds from the bank of England.
-* [House Prices](/core/house-prices-uk) - UK house prices since 1953 as monthly time-series.
-* [Interest Rates](/core/interest-rates-gb) - Interest Rate since 1694 from Bank of England.
+* [GDP](https://datahub.io/core/gdp-uk) - UK Real GDP since 1948 from the Office of National Statistics.
+* [Bond Yields](https://datahub.io/core/bond-yields-uk-10y) - 10 year nominal yields on UK government bonds from the bank of England.
+* [House Prices](https://datahub.io/core/house-prices-uk) - UK house prices since 1953 as monthly time-series.
+* [Interest Rates](https://datahub.io/core/interest-rates-gb) - Interest Rate since 1694 from Bank of England.
 
 ## World Bank data
 
 World Bank is a one of the best sources of different datasets including economic data. Please, read the following article about World Bank data collections, API and more:
 
-[awesome/world-bank](/awesome/world-bank)
+[awesome/world-bank](https://datahub.io/awesome/world-bank)
 
 ## International Monetary Fund (IMF)
 
 IMF World Economic Outlook (WEO) database. The source database is made of annual values for each country on 45 indicators since 1980. In addition the database includes the IMF projects approximately 6 years into the future.
 
-[core/imf-weo](/core/imf-weo)
+[core/imf-weo](https://datahub.io/core/imf-weo)
 
 ## Other economic data and indicators
 
-* [Corruption Perceptions Index](/core/corruption-perceptions-index)
-* [Euribor](/core/euribor) - Euribor rates by year and granularity. Only monthly granularity is provided.
-* [Exchange Rates](/core/exchange-rates) - Foreign exchange rates from US Federal Reserve in daily, monthly and yearly basis.
-* [Expenditure on Research and Development](/core/expenditure-on-research-and-development)
-* [GINI Index](/core/gini-index) - Historic values of the GINI Index.
-* [Global House Prices](/core/house-prices-global) - Residential property price statistics from different countries.
-* [Population Growth Estimates and Projections](/core/population-growth-estimates-and-projections)
-* [Purchasing Power Parity (PPP)](/core/ppp)
-* [Brent and WTI Spot Prices](/core/oil-prices) - Europe Brent and WTI (Western Texas Intermediate) Spot Prices (Annual/ Monthly/ Weekly/ Daily).
-* [Natural gas prices](/core/natural-gas) - Time series of major Natural Gas Prices including US Henry Hub.
-* [Gold Prices](/core/gold-prices) - Monthly gold prices since 1950 in USD (London market).
+* [Corruption Perceptions Index](https://datahub.io/core/corruption-perceptions-index)
+* [Euribor](https://datahub.io/core/euribor) - Euribor rates by year and granularity. Only monthly granularity is provided.
+* [Exchange Rates](https://datahub.io/core/exchange-rates) - Foreign exchange rates from US Federal Reserve in daily, monthly and yearly basis.
+* [Expenditure on Research and Development](https://datahub.io/core/expenditure-on-research-and-development)
+* [GINI Index](https://datahub.io/core/gini-index) - Historic values of the GINI Index.
+* [Global House Prices](https://datahub.io/core/house-prices-global) - Residential property price statistics from different countries.
+* [Population Growth Estimates and Projections](https://datahub.io/core/population-growth-estimates-and-projections)
+* [Purchasing Power Parity (PPP)](https://datahub.io/core/ppp)
+* [Brent and WTI Spot Prices](https://datahub.io/core/oil-prices) - Europe Brent and WTI (Western Texas Intermediate) Spot Prices (Annual/ Monthly/ Weekly/ Daily).
+* [Natural gas prices](https://datahub.io/core/natural-gas) - Time series of major Natural Gas Prices including US Henry Hub.
+* [Gold Prices](https://datahub.io/core/gold-prices) - Monthly gold prices since 1950 in USD (London market).

--- a/education.md
+++ b/education.md
@@ -11,10 +11,10 @@ image: education.png
 
 United States of America Education budget to GDP analysis:
 
-[core/usa-education-budget-analysis](/core/usa-education-budget-analysis)
+[core/usa-education-budget-analysis](https://datahub.io/core/usa-education-budget-analysis)
 
 ## CIRP Freshmen Survey
 
 CIRP survey of the american freshmen conducted in 2014. Contains student’s opinions on various matters as well as information about institutions participating in a survey:
 
-[core/cirp-survey-of-freshmen](/core/cirp-survey-of-freshmen)
+[core/cirp-survey-of-freshmen](https://datahub.io/core/cirp-survey-of-freshmen)

--- a/football.md
+++ b/football.md
@@ -13,8 +13,6 @@ A collection of awesome football datasets including national teams, clubs, match
 
 Note: :octocat: stands for the GitHub page, :gem: stands for the RubyGems page and :datahub: stands for dataset on DataHub.
 
-[[toc]]
-
 # Football Data Guides / Articles
 
 _Where's the open football data?_

--- a/geojson.md
+++ b/geojson.md
@@ -11,7 +11,7 @@ image: geojson.png
 
 Geo Boundaries for NUTS administrative levels 1, 2 and 3 edition 2013:
 
-[core/geo-nuts-administrative-boundaries](/core/geo-nuts-administrative-boundaries)
+[core/geo-nuts-administrative-boundaries](https://datahub.io/core/geo-nuts-administrative-boundaries)
 
 If you don't know what NUTS (Nomenclature of Territorial Units for Statistics) are, see the [related Wikipedia article](https://en.wikipedia.org/wiki/Nomenclature_of_Territorial_Units_for_Statistics).
 
@@ -19,13 +19,13 @@ If you don't know what NUTS (Nomenclature of Territorial Units for Statistics) a
 
 Geodata data package providing geojson polygons for all the world’s countries. Perfect for use in apps and visualizations:
 
-[core/geo-countries](/core/geo-countries)
+[core/geo-countries](https://datahub.io/core/geo-countries)
 
 ## Natural Earth Admin1 Polygons as GeoJSON
 
 Geodata data package providing geojson polygons for the largest administrative subdivisions in every countries:
 
-[core/geo-ne-admin1](/core/geo-ne-admin1)
+[core/geo-ne-admin1](https://datahub.io/core/geo-ne-admin1)
 
 ## Natural Earth Admin1 Polygons as GeoJSON US
 

--- a/geojson.md
+++ b/geojson.md
@@ -7,8 +7,6 @@ modified: 2018-06-07
 image: geojson.png
 ---
 
-[[toc]]
-
 ## European NUTS boundaries as GeoJSON at 1:60m
 
 Geo Boundaries for NUTS administrative levels 1, 2 and 3 edition 2013:

--- a/healthcare-data.md
+++ b/healthcare-data.md
@@ -11,10 +11,10 @@ image: healthcare-data.png
 
 DNA Sequencing Costs:
 
-[core/genome-sequencing-costs](/core/genome-sequencing-costs)
+[core/genome-sequencing-costs](https://datahub.io/core/genome-sequencing-costs)
 
 ## Pharmaceutical Drug Spending by countries (data analytics)
 
 Pharmaceutical Drug Spending by countries with indicators such as a share of total health spending, in USD per capita (using economy-wide PPPs) and as a share of GDP. Plus, total spending by each countries in the specific year:
 
-[core/pharmaceutical-drug-spending](/core/pharmaceutical-drug-spending)
+[core/pharmaceutical-drug-spending](https://datahub.io/core/pharmaceutical-drug-spending)

--- a/inflation.md
+++ b/inflation.md
@@ -6,5 +6,5 @@ modified: 2018-06-06
 image: inflation.png
 ---
 
-* Annual inflation by GDP deflator and consumer prices: [core/inflation](/core/inflation)
-* US Consumer Price Index and Inflation (CPI): [core/cpi-us](/core/cpi-us)
+* Annual inflation by GDP deflator and consumer prices: [core/inflation](https://datahub.io/core/inflation)
+* US Consumer Price Index and Inflation (CPI): [core/cpi-us](https://datahub.io/core/cpi-us)

--- a/linked-open-data.md
+++ b/linked-open-data.md
@@ -9,8 +9,6 @@ image: linked-open-data.png
 
 A group for Linked Open Data datasets. The initial import of data for this group was done in October 2009 from the list of [RDF datasets dumps](https://www.w3.org/wiki/DataSetRDFDumps) provided by the W3C Linked Open Data Interest Group.
 
-[[toc]]
-
 ## DBpedia
 
 DBpedia.org is a community effort to extract structured information from Wikipedia and to make this information available on the Web. DBpedia allows you to ask sophisticated queries against Wikipedia and to link other datasets on the Web to Wikipedia data.

--- a/logistics-data.md
+++ b/logistics-data.md
@@ -9,8 +9,6 @@ image: logistics-data.png
 
 Summary list of datasets available on DataHub that are related to Logistics.
 
-[[toc]]
-
 ## List of countries
 
 ISO 3166-1-alpha-2 English country names and code elements. This list states

--- a/logistics-data.md
+++ b/logistics-data.md
@@ -15,7 +15,7 @@ ISO 3166-1-alpha-2 English country names and code elements. This list states
 the country names (official short names in English) in alphabetical order as
 given in [ISO 3166-1][] and the corresponding ISO 3166-1-alpha-2 code elements:
 
-[core/country-list](/core/country-list)
+[core/country-list](https://datahub.io/core/country-list)
 
 [ISO 3166-1]: http://www.iso.org/iso/home/standards/country_codes.htm
 
@@ -23,31 +23,31 @@ given in [ISO 3166-1][] and the corresponding ISO 3166-1-alpha-2 code elements:
 
 Airport codes from around the world:
 
-[core/airport-codes](/core/airport-codes)
+[core/airport-codes](https://datahub.io/core/airport-codes)
 
 ## Country codes
 
 Comprehensive country code information, including ISO 3166 codes, ITU dialing codes, ISO 4217 currency codes, and many others:
 
-[core/country-codes](/core/country-codes)
+[core/country-codes](https://datahub.io/core/country-codes)
 
 ## Continent codes
 
 A list of the seven continents with English names and short, unique and permanent identifying codes:
 
-[core/continent-codes](/core/continent-codes)
+[core/continent-codes](https://datahub.io/core/continent-codes)
 
 ## UN Locode
 
 The United Nations Code for Trade and Transport Locations is a code list maintained by UNECE, United Nations agency, to facilitate trade:
 
-[core/un-locode](/core/un-locode)
+[core/un-locode](https://datahub.io/core/un-locode)
 
 ## ISO 6346 Container Type Codes
 
 Coded list of ISO 6346 shipping containers, used in international trade and electronic shipping messages:
 
-[core/iso-container-codes](/core/iso-container-codes)
+[core/iso-container-codes](https://datahub.io/core/iso-container-codes)
 
 ## World cities
 

--- a/stock-market-data.md
+++ b/stock-market-data.md
@@ -11,52 +11,52 @@ image: stock-market-data.png
 
 List of companies in the S&P 500 (Standard and Poor’s 500). The S&P 500 is a free-float, capitalization-weighted index of the top 500 publicly listed stocks in the US (top 500 by market cap). The dataset includes a list of all the stocks contained therein:
 
-[core/s-and-p-500-companies](/core/s-and-p-500-companies)
+[core/s-and-p-500-companies](https://datahub.io/core/s-and-p-500-companies)
 
 ## S&P 500 Companies with Financial Information
 
 List of companies in the S&P 500 (Standard and Poor’s 500). The dataset includes a list of all the stocks contained therein and associated key financials such as price, market capitalization, earnings, price/earnings ratio, price to book etc.:
 
-[core/s-and-p-500-companies-financials](/core/s-and-p-500-companies-financials)
+[core/s-and-p-500-companies-financials](https://datahub.io/core/s-and-p-500-companies-financials)
 
 ## Standard and Poor's (S&P) 500 Index Data including Dividend, Earnings and P/E Ratio
 
 S&P 500 index data including level, dividend, earnings and P/E ratio on a monthly basis since 1870:
 
-[core/s-and-p-500](/core/s-and-p-500)
+[core/s-and-p-500](https://datahub.io/core/s-and-p-500)
 
 ## VIX - CBOE Volatility Index
 
 CBOE Volatility Index (VIX) time-series dataset including daily open, close, high and low:
 
-[core/finance-vix](/core/finance-vix)
+[core/finance-vix](https://datahub.io/core/finance-vix)
 
 ## NYSE and Other Listings
 
 List of companies in the NYSE, and other exchanges:
 
-[core/nyse-other-listings](/core/nyse-other-listings)
+[core/nyse-other-listings](https://datahub.io/core/nyse-other-listings)
 
 ## NASDAQ listings
 
 List of companies in the NASDAQ exchanges:
 
-[core/nasdaq-listings](/core/nasdaq-listings)
+[core/nasdaq-listings](https://datahub.io/core/nasdaq-listings)
 
 ## Brent and WTI Spot Prices
 
 Europe Brent and WTI (Western Texas Intermediate) Spot Prices (Annual/ Monthly/ Weekly/ Daily) from EIA U.S. (Energy Information Administration):
 
-[core/oil-prices](/core/oil-prices)
+[core/oil-prices](https://datahub.io/core/oil-prices)
 
 ## Natural gas prices
 
 Time series of major Natural Gas Prices including US Henry Hub. Data comes from U.S. Energy Information Administration EIA:
 
-[core/natural-gas](/core/natural-gas)
+[core/natural-gas](https://datahub.io/core/natural-gas)
 
 ## Gold Prices
 
 Monthly gold prices since 1950 in USD (London market). Data is sourced from the Bundesbank:
 
-[core/gold-prices](/core/gold-prices)
+[core/gold-prices](https://datahub.io/core/gold-prices)

--- a/stock-market-data.md
+++ b/stock-market-data.md
@@ -7,8 +7,6 @@ modified: 2018-06-07
 image: stock-market-data.png
 ---
 
-[[toc]]
-
 ## S&P 500 companies
 
 List of companies in the S&P 500 (Standard and Poor’s 500). The S&P 500 is a free-float, capitalization-weighted index of the top 500 publicly listed stocks in the US (top 500 by market cap). The dataset includes a list of all the stocks contained therein:

--- a/war-and-peace.md
+++ b/war-and-peace.md
@@ -9,8 +9,6 @@ image: war-and-peace.png
 
 Data on inter-state conflicts, international relations and other correlates of war including war-related deaths and injuries.
 
-[[toc]]
-
 ## Uppsala Conflict Data Program (UCDP) dataset
 
 A whole variety of datasets on armed conflicts 1946-present


### PR DESCRIPTION
## Changes made:
- Removed broken `toc` links in the `awesome-dataset`
- Updated the broken links example `core/euribor` -> `https://datahub.io/core/euribor`

## References:
Issue [#1310](https://github.com/datopian/datahub/issues/1310)
Issue [#1311](https://github.com/datopian/datahub/issues/1311)