### PR TITLE
Add Statistics of the World to Economic Data page

### DIFF
--- a/economic-data.md
+++ b/economic-data.md
@@ -67,3 +67,7 @@ IMF World Economic Outlook (WEO) database. The source database is made of annual
 * [Brent and WTI Spot Prices](https://datahub.io/core/oil-prices) - Europe Brent and WTI (Western Texas Intermediate) Spot Prices (Annual/ Monthly/ Weekly/ Daily).
 * [Natural gas prices](https://datahub.io/core/natural-gas) - Time series of major Natural Gas Prices including US Henry Hub.
 * [Gold Prices](https://datahub.io/core/gold-prices) - Monthly gold prices since 1950 in USD (London market).
+
+## Aggregated Economic Data Platforms
+
+* [Statistics of the World](https://statisticsoftheworld.com/) - 440+ economic, demographic, health, and environmental indicators for 218 countries (1960–2026). Aggregates data from IMF, World Bank, WHO, FRED, and UN. Free REST API available. Interactive charts, rankings, and country comparisons.


### PR DESCRIPTION
Adds [Statistics of the World](https://statisticsoftheworld.com/) to the Economic Data page under a new "Aggregated Economic Data Platforms" section.

- 440+ indicators for 218 countries (1960–2026)
- Sources: IMF WEO, World Bank WDI, WHO GHO, FRED, UN
- Free REST API (no auth required)
- Interactive charts, country rankings, and side-by-side comparisons
- CC BY 4.0 licensed