### PR TITLE
Add OpenMercantil dataset entry

### DIFF
--- a/d/openmercantil.md
+++ b/d/openmercantil.md
@@ -1,0 +1,28 @@
+---
+title: "OpenMercantil: Spanish public mercantile data reuse"
+created: 2026-07-04
+homepage: https://openmercantil.es/
+---
+
+<img width="1200" alt="OpenMercantil" src="https://openmercantil.es/assets/img/og-default.png" />
+
+OpenMercantil is an independent Spanish public-data reuse project that makes public mercantile/company information easier to search, understand and reuse.
+
+It structures information derived from the Boletin Oficial del Registro Mercantil (BORME) and other public sources into searchable company pages, registry-event timelines, documented sources and methodology notes, downloadable resources and a documented API.
+
+The project is designed as a practical discovery and reuse layer for citizens, journalists, researchers, developers, small businesses, analysts and public-interest users who need easier access to Spanish company context without treating the service as an official registry or certification source.
+
+OpenMercantil is not the BOE, the BORME, the Registro Mercantil or a public administration. For legal certainty, official registry documents and original public sources remain authoritative.
+
+License: CC BY 4.0 for OpenMercantil-derived public-data outputs, with attribution to OpenMercantil and preservation of the original public-source context. Reusers should review source-specific attribution and reuse conditions where relevant.
+
+Useful links:
+
+- Project: https://openmercantil.es/
+- API documentation: https://openmercantil.es/api/documentacion
+- OpenAPI spec: https://openmercantil.es/openapi.json
+- Downloads: https://openmercantil.es/descargas
+- Sources: https://openmercantil.es/fuentes
+- Methodology: https://openmercantil.es/metodologia
+- Free access / pricing: https://openmercantil.es/precios
+- data.europa.eu case note: https://data.europa.eu/en/news-events/news/spanish-example-public-data-reuse-case-openmercantil


### PR DESCRIPTION
This adds an OpenMercantil entry under `d/`, as suggested in #431.

Included:

- short project description
- screenshot/preview image from the live OpenMercantil site
- license wording for OpenMercantil-derived public-data outputs
- links to API documentation, OpenAPI spec, downloads, sources and methodology
- caveat that OpenMercantil is independent and not an official registry/certification source
- data.europa.eu case note as external context

Related issue: #431